### PR TITLE
Fix unsafe pointer conversion when exchanging keys

### DIFF
--- a/Client/main.go
+++ b/Client/main.go
@@ -91,12 +91,19 @@ func (c *Client) ExchangeKeys() error {
 		return fmt.Errorf("server returned an error: %s", result.Error)
 	}
 
-	serverPublicKey, err := hex.DecodeString(result.ServerPublicKey)
+	serverPublicKeyBytes, err := hex.DecodeString(result.ServerPublicKey)
 	if err != nil {
 		return fmt.Errorf("failed to decode server public key: %w", err)
 	}
 
-	c.K1, err = Cipher.CreateSharedKey(c.PrivateKey, *(*[32]byte)(serverPublicKey))
+	if len(serverPublicKeyBytes) != 32 {
+		return fmt.Errorf("server public key length mismatch")
+	}
+
+	var serverPublicKey [32]byte
+	copy(serverPublicKey[:], serverPublicKeyBytes)
+
+	c.K1, err = Cipher.CreateSharedKey(c.PrivateKey, serverPublicKey)
 	if err != nil {
 		return fmt.Errorf("failed to create K1: %w", err)
 	}


### PR DESCRIPTION
## Summary
- fix unsafe cast when creating shared keys from hex strings
- validate key lengths

## Testing
- `go vet ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_683f43ec40788333a59fc96003c6f546