### PR TITLE
Handle binary.Write result and add DeriveEAPI test

### DIFF
--- a/Cipher/kdf.go
+++ b/Cipher/kdf.go
@@ -25,6 +25,12 @@ func DeriveK3(k2 []byte) ([]byte, error) {
 
 func DeriveEAPI(k3 []byte, timestamp int64) []byte {
 	h := hmac.New(sha256.New, k3)
-	binary.Write(h, binary.BigEndian, timestamp)
+	// Writing to an in-memory hash should never fail but we capture the
+	// error for completeness.
+	if err := binary.Write(h, binary.BigEndian, timestamp); err != nil {
+		// panic is acceptable here since failure indicates a bug in the
+		// underlying implementation and cannot be recovered from.
+		panic(err)
+	}
 	return h.Sum(nil)
 }

--- a/Cipher/kdf_test.go
+++ b/Cipher/kdf_test.go
@@ -1,0 +1,28 @@
+package Cipher
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/binary"
+	"testing"
+)
+
+func TestDeriveEAPI(t *testing.T) {
+	k3 := bytes.Repeat([]byte{0x01}, 32)
+	timestamp := int64(1234567890)
+
+	// Manually compute expected HMAC
+	buf := new(bytes.Buffer)
+	if err := binary.Write(buf, binary.BigEndian, timestamp); err != nil {
+		t.Fatalf("binary.Write failed: %v", err)
+	}
+	h := hmac.New(sha256.New, k3)
+	h.Write(buf.Bytes())
+	expected := h.Sum(nil)
+
+	got := DeriveEAPI(k3, timestamp)
+	if !bytes.Equal(got, expected) {
+		t.Errorf("DeriveEAPI() = %x, want %x", got, expected)
+	}
+}


### PR DESCRIPTION
## Summary
- add error handling to DeriveEAPI
- add unit test for DeriveEAPI

## Testing
- `go test ./...` inside Cipher module

------
https://chatgpt.com/codex/tasks/task_e_683f58004da48333a0d45b1dff701220