### PR TITLE
chore: tidy modules and format code

### DIFF
--- a/playground/kdf_test.go
+++ b/playground/kdf_test.go
@@ -1,30 +1,30 @@
 package playground
 
 import (
-    "bytes"
-    "crypto/hmac"
-    "crypto/sha256"
-    "encoding/binary"
-    "testing"
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/binary"
+	"testing"
 
-    cipherpkg "E2E2/Cipher"
+	cipherpkg "E2E2/Cipher"
 )
 
 func TestDeriveEAPI(t *testing.T) {
-    k3 := bytes.Repeat([]byte{0x01}, 32)
-    timestamp := int64(1234567890)
+	k3 := bytes.Repeat([]byte{0x01}, 32)
+	timestamp := int64(1234567890)
 
-    // Manually compute expected HMAC
-    buf := new(bytes.Buffer)
-    if err := binary.Write(buf, binary.BigEndian, timestamp); err != nil {
-        t.Fatalf("binary.Write failed: %v", err)
-    }
-    h := hmac.New(sha256.New, k3)
-    h.Write(buf.Bytes())
-    expected := h.Sum(nil)
+	// Manually compute expected HMAC
+	buf := new(bytes.Buffer)
+	if err := binary.Write(buf, binary.BigEndian, timestamp); err != nil {
+		t.Fatalf("binary.Write failed: %v", err)
+	}
+	h := hmac.New(sha256.New, k3)
+	h.Write(buf.Bytes())
+	expected := h.Sum(nil)
 
-    got := cipherpkg.DeriveEAPI(k3, timestamp)
-    if !bytes.Equal(got, expected) {
-        t.Errorf("DeriveEAPI() = %x, want %x", got, expected)
-    }
+	got := cipherpkg.DeriveEAPI(k3, timestamp)
+	if !bytes.Equal(got, expected) {
+		t.Errorf("DeriveEAPI() = %x, want %x", got, expected)
+	}
 }

--- a/playground/server_test.go
+++ b/playground/server_test.go
@@ -1,98 +1,98 @@
 package playground
 
 import (
-    "net/http/httptest"
-    "os"
-    "path/filepath"
-    "testing"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
 
-    clientpkg "E2E2/Client"
-    serverpkg "E2E2/Server"
-    "github.com/gin-gonic/gin"
+	clientpkg "E2E2/Client"
+	serverpkg "E2E2/Server"
+	"github.com/gin-gonic/gin"
 )
 
 func TestSessionPersistenceAcrossRestarts(t *testing.T) {
-    gin.SetMode(gin.TestMode)
+	gin.SetMode(gin.TestMode)
 
-    tempDir := t.TempDir()
-    wd, err := os.Getwd()
-    if err != nil {
-        t.Fatalf("getwd: %v", err)
-    }
-    defer os.Chdir(wd)
-    if err := os.Chdir(tempDir); err != nil {
-        t.Fatalf("chdir: %v", err)
-    }
+	tempDir := t.TempDir()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	defer os.Chdir(wd)
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
 
-    // Start first server
-    srv1, err := serverpkg.NewServer()
-    if err != nil {
-        t.Fatalf("NewServer: %v", err)
-    }
+	// Start first server
+	srv1, err := serverpkg.NewServer()
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
 
-    r1 := gin.Default()
-    r1.POST("/exchange-keys", srv1.HandleKeyExchange)
-    r1.POST("/tunnel", srv1.HandleTunnel(func(s string) string {
-        if s == "ping" {
-            return "pong"
-        }
-        return s
-    }))
+	r1 := gin.Default()
+	r1.POST("/exchange-keys", srv1.HandleKeyExchange)
+	r1.POST("/tunnel", srv1.HandleTunnel(func(s string) string {
+		if s == "ping" {
+			return "pong"
+		}
+		return s
+	}))
 
-    ts1 := httptest.NewServer(r1)
+	ts1 := httptest.NewServer(r1)
 
-    client, err := clientpkg.NewClient(ts1.URL)
-    if err != nil {
-        t.Fatalf("NewClient: %v", err)
-    }
-    if err := client.ExchangeKeys(); err != nil {
-        t.Fatalf("ExchangeKeys: %v", err)
-    }
+	client, err := clientpkg.NewClient(ts1.URL)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	if err := client.ExchangeKeys(); err != nil {
+		t.Fatalf("ExchangeKeys: %v", err)
+	}
 
-    resp, err := client.Send("ping")
-    if err != nil || resp != "pong" {
-        t.Fatalf("first ping failed: %v %s", err, resp)
-    }
+	resp, err := client.Send("ping")
+	if err != nil || resp != "pong" {
+		t.Fatalf("first ping failed: %v %s", err, resp)
+	}
 
-    ts1.Close()
+	ts1.Close()
 
-    // Path to the session file for later checks
-    sessFile := filepath.Join(tempDir, "server_sessions.json")
+	// Path to the session file for later checks
+	sessFile := filepath.Join(tempDir, "server_sessions.json")
 
-    // Restart server
-    srv2, err := serverpkg.NewServer()
-    if err != nil {
-        t.Fatalf("NewServer2: %v", err)
-    }
+	// Restart server
+	srv2, err := serverpkg.NewServer()
+	if err != nil {
+		t.Fatalf("NewServer2: %v", err)
+	}
 
-    r2 := gin.Default()
-    r2.POST("/exchange-keys", srv2.HandleKeyExchange)
-    r2.POST("/tunnel", srv2.HandleTunnel(func(s string) string {
-        if s == "ping" {
-            return "pong"
-        }
-        return s
-    }))
+	r2 := gin.Default()
+	r2.POST("/exchange-keys", srv2.HandleKeyExchange)
+	r2.POST("/tunnel", srv2.HandleTunnel(func(s string) string {
+		if s == "ping" {
+			return "pong"
+		}
+		return s
+	}))
 
-    ts2 := httptest.NewServer(r2)
-    defer ts2.Close()
+	ts2 := httptest.NewServer(r2)
+	defer ts2.Close()
 
-    client.ServerURL = ts2.URL
+	client.ServerURL = ts2.URL
 
-    resp, err = client.Send("ping")
-    if err != nil || resp != "pong" {
-        t.Fatalf("ping after restart failed: %v %s", err, resp)
-    }
+	resp, err = client.Send("ping")
+	if err != nil || resp != "pong" {
+		t.Fatalf("ping after restart failed: %v %s", err, resp)
+	}
 
-    srv2.SessionMu.RLock()
-    _, exists := srv2.Sessions[client.SessionID]
-    srv2.SessionMu.RUnlock()
-    if !exists {
-        t.Fatalf("session not loaded on restart")
-    }
+	srv2.SessionMu.RLock()
+	_, exists := srv2.Sessions[client.SessionID]
+	srv2.SessionMu.RUnlock()
+	if !exists {
+		t.Fatalf("session not loaded on restart")
+	}
 
-    _, err = os.Stat(sessFile)
-    if err != nil {
-        t.Fatalf("session file missing after restart: %v", err)
-    }
+	_, err = os.Stat(sessFile)
+	if err != nil {
+		t.Fatalf("session file missing after restart: %v", err)
+	}
 }

--- a/project/Server/go.mod
+++ b/project/Server/go.mod
@@ -33,7 +33,6 @@ require (
 
 require (
 	E2E2/Cipher v0.0.0
-	E2E2/Client v0.0.0
 	E2E2/Storage v0.0.0
 	github.com/gin-gonic/gin v1.10.0
 	github.com/google/uuid v1.6.0

--- a/project/Storage/init.go
+++ b/project/Storage/init.go
@@ -11,7 +11,7 @@ func Init(Name string) *Client {
 	}
 
 	if _, err := os.Stat(client.File); os.IsNotExist(err) {
-		client.Save() 
+		client.Save()
 	} else {
 		client.Load()
 	}


### PR DESCRIPTION
## Summary
- remove unused `E2E2/Client` module from server dependencies
- run `gofmt` across tests and storage init

## Testing
- `go test ./...` in playground
- `go test ./...` in each project module

------
https://chatgpt.com/codex/tasks/task_e_683f5df7d8e883338dda16406cff8597